### PR TITLE
Add util shim for isString and isObject, for compatibility with earlier node

### DIFF
--- a/path.js
+++ b/path.js
@@ -21,7 +21,7 @@
 
 
 var isWindows = process.platform === 'win32';
-var util = require('util');
+var util = require('./util');
 
 var _path = require('path');
 

--- a/util.js
+++ b/util.js
@@ -1,0 +1,20 @@
+var _util = require('util');
+
+function isString(arg) {
+  return typeof arg === 'string';
+}
+
+function isObject(arg) {
+  return typeof arg === 'object' && arg !== null;
+}
+
+
+exports = module.exports = _util;
+
+if (!_util.isString) {
+  exports.isString = isString;
+}
+
+if (!_util.isObject) {
+  exports.isObject = isObject;
+}


### PR DESCRIPTION
The `util` module in node 0.10.x and earlier doesn't provide `isString` or `isObject` implementations, making this package less transitional.  I've added shims for those using the code from node 0.11.15 here: https://github.com/joyent/node/blob/8a9f263a82089814e69f277f9fecd2888705101b/lib/util.js

This makes the module usable on node 0.10.x and earlier.
